### PR TITLE
Fix error of method declaration

### DIFF
--- a/src/Components/Step.php
+++ b/src/Components/Step.php
@@ -85,7 +85,7 @@ abstract class Step extends ViewComponent implements Htmlable
         return $this;
     }
 
-    public function view(string $view): static
+    public function setView(string $view): static
     {
         $this->view = $view;
 


### PR DESCRIPTION
PHP Fatal error:  Declaration of Vildanbina\LivewireWizard\Components\Step::view(string $view): static must be compatible with Illuminate\View\Component::view($view, $data = [], $mergeData = []) in /var/www/html/vendor/vildanbina/livewire-wizard/src/Components/Step.php on line 88